### PR TITLE
Migrate torch.cuda.amp.autocast to torch.amp

### DIFF
--- a/docta/apis/train.py
+++ b/docta/apis/train.py
@@ -45,7 +45,7 @@ def test_model(cfg, model, dataset):
         else:
             labels = batch[1].to(cfg.device)
         # labels = batch[1][:, cfg.test_label_sel].to(cfg.device)
-        with torch.cuda.amp.autocast():
+        with torch.amp.autocast("cuda"):
             _, logits = model(features)
         prec = accuracy(logits, labels) 
         test_total += 1
@@ -72,7 +72,7 @@ def train_model(cfg, model, dataset, loss_func, test_dataset=None):
                 labels = batch[1][:, cfg.train_label_sel].to(cfg.device)
             else:
                 labels = batch[1].to(cfg.device)
-            with torch.cuda.amp.autocast():
+            with torch.amp.autocast("cuda"):
                 _, logits = model(features)
             prec = accuracy(logits, labels) 
             train_total += 1

--- a/docta/core/preprocess.py
+++ b/docta/core/preprocess.py
@@ -69,14 +69,14 @@ def extract_embedding_batch(cfg, encoder, batch_feature):
     try:
         encoder, tokenizer = encoder
         encoded_input = tokenizer(batch_feature).to(cfg.device)
-        with torch.no_grad(), torch.cuda.amp.autocast():
+        with torch.no_grad(), torch.amp.autocast("cuda"):
             model_output = encoder(**encoded_input)
         # Perform pooling
         sentence_embeddings = mean_pooling(model_output, encoded_input['attention_mask'])
         # Normalize embeddings
         embedding = F.normalize(sentence_embeddings, p=2, dim=1)
     except: 
-        with torch.no_grad(), torch.cuda.amp.autocast():
+        with torch.no_grad(), torch.amp.autocast("cuda"):
             embedding = encoder(batch_feature.to(cfg.device))
     return embedding
 


### PR DESCRIPTION
Fixes #7

### Summary

`torch.cuda.amp.autocast` has been deprecated since torch 2.4 and is scheduled for removal. This PR migrates the four uses in the core `docta/` package to `torch.amp`:

- [docta/apis/train.py:48, 75](https://github.com/Docta-ai/docta/blob/main/docta/apis/train.py#L48) — test loop and `train_epoch`:
  ```diff
  -        with torch.cuda.amp.autocast():
  +        with torch.amp.autocast("cuda"):
  ```
- [docta/core/preprocess.py:72, 79](https://github.com/Docta-ai/docta/blob/main/docta/core/preprocess.py#L72) — `extract_embedding_batch` (embedding extraction, exported via `docta/apis/__init__.py`):
  ```diff
  -        with torch.no_grad(), torch.cuda.amp.autocast():
  +        with torch.no_grad(), torch.amp.autocast("cuda"):
  ```

`torch.amp.autocast("cuda", ...)` is available since torch 2.0 and compatible with the declared `torch>=2.0.0` floor.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Validation

Verified on torch 2.11.0 with `warnings.simplefilter("error", FutureWarning)`:

- `torch.amp.autocast("cuda", ...)` constructs warning-free (autocast is disabled when CUDA is unavailable, by design).
- Control group: `torch.cuda.amp.autocast()` raises `FutureWarning` under the same filter — the fix is effective and the filter is sensitive.
- `py_compile` passes on both touched files; the repo has zero `torch.cuda.amp` references (grep-verified).

### User impact

No behavior change; the `FutureWarning` emitted by every training/test run and embedding extraction on torch 2.4+ is eliminated, as is the breakage risk once `torch.cuda.amp` is removed.

### Notes for reviewers

- Same migration as [ultralytics/yolov5#13244](https://github.com/ultralytics/yolov5/pull/13244) and [huggingface/lerobot#3167](https://github.com/huggingface/lerobot/pull/3167).
